### PR TITLE
Boost154n ruby193p547

### DIFF
--- a/rakefile
+++ b/rakefile
@@ -23,6 +23,9 @@ DOCUMENTATION_FOLDER = File.expand_path 'documentation'
 HOME_FOLDER = Dir.home
 BOOST_LIBRARY_FOLDER =  File.absolute_path("/usr/lib/x86_64-linux-gnu")
 BOOST_INCLUDE_FOLDER = File.absolute_path("/usr/include/boost")
+RUBY_INSTALL_FOLDER = File.absolute_path("#{HOME_FOLDER}/.rvm/rubies/ruby-1.9.3-p547/include/ruby-1.9.1/")
+RUBY_H_FOLDER = File.absolute_path("#{RUBY_INSTALL_FOLDER}/x86_64-linux")
+
 
 OBJECT_FILE_EXT = 'o'
 DEPENDS_FILE_EXT = 'd'
@@ -37,8 +40,8 @@ ADDITIONAL_DEFINES_FLAG = ADDITIONAL_DEFINES.nil? ? '' : "-D#{ADDITIONAL_DEFINES
 COMPILER_FLAGS = "-Wall -pedantic -Wno-parentheses -Wno-sign-compare \
   -fPIC -c -pipe -I#{INCLUDE_FOLDER}   \
   -I #{BOOST_INCLUDE_FOLDER} \
-  -I #{HOME_FOLDER}/.rvm/rubies/ruby-1.9.3-p547/include/ruby-1.9.1/ \
-  -I #{HOME_FOLDER}/.rvm/rubies/ruby-1.9.3-p547/include/ruby-1.9.1/x86_64-linux \
+  -I #{RUBY_INSTALL_FOLDER} \
+  -I #{RUBY_H_FOLDER} \
   #{ADDITIONAL_DEFINES_FLAG}"
 COMPILER_FLAGS_BY_FLAVORS = {
 	'debug' => '-ggdb -O0',

--- a/source/tests/bayeux_chat.cpp
+++ b/source/tests/bayeux_chat.cpp
@@ -129,7 +129,8 @@ int main()
     file::add_file_handler( server, "/", boost::filesystem::canonical( __FILE__ ).parent_path() / "bayeux_chat" );
 
     using namespace boost::asio::ip;
-    server.add_listener( tcp::endpoint( address( address_v4::any() ), 8080u ) );
+	// JRL -- comment out for boost 1_55 support otherwise an exception is thrown "bind: Address already in use"
+    // server.add_listener( tcp::endpoint( address( address_v4::any() ), 8080u ) );
     server.add_listener( tcp::endpoint( address( address_v6::any() ), 8080u ) );
 
     std::cout << "browse for \"http://localhost:8080/\"" << std::endl;

--- a/source/tests/chat.cpp
+++ b/source/tests/chat.cpp
@@ -121,8 +121,9 @@ int main()
     file::add_file_handler( server, "/", boost::filesystem::canonical( __FILE__ ).parent_path() / "chat" );
 
     using namespace boost::asio::ip;
-    server.add_listener( tcp::endpoint( address( address_v4::any() ), 8080u ) );
-    // server.add_listener( tcp::endpoint( address( address_v6::any() ), 8080u ) );
+    // JRL -- comment out for boost 1_55 support otherwise an exception is thrown "bind: Address already in use"
+    // server.add_listener( tcp::endpoint( address( address_v4::any() ), 8080u ) );
+    server.add_listener( tcp::endpoint( address( address_v6::any() ), 8080u ) );
 
     std::cout << "browse for \"http://localhost:8080/\"" << std::endl;
 


### PR DESCRIPTION
Minor changes to the top level rakefile to support using a configurable version of boost libraries and an rvm installed version of ruby. 

Also minor changes to chat.cpp and bayeux_chat.cpp that seems to be needed by boost 1_54 to prevent a "bind exception", which complains with a message indicating that the "Address already in use" 
