### PR TITLE
Minor changes, mostly comments and one unnecessary server.add_action()

### DIFF
--- a/source/tests/bayeux_chat.cpp
+++ b/source/tests/bayeux_chat.cpp
@@ -129,7 +129,7 @@ int main()
     file::add_file_handler( server, "/", boost::filesystem::canonical( __FILE__ ).parent_path() / "bayeux_chat" );
 
     using namespace boost::asio::ip;
-	// JRL -- comment out for boost 1_55 support otherwise an exception is thrown "bind: Address already in use"
+	// JRL -- comment out for boost 1_54 support otherwise an exception is thrown "bind: Address already in use"
     // server.add_listener( tcp::endpoint( address( address_v4::any() ), 8080u ) );
     server.add_listener( tcp::endpoint( address( address_v6::any() ), 8080u ) );
 

--- a/source/tests/chat.cpp
+++ b/source/tests/chat.cpp
@@ -115,13 +115,12 @@ int main()
     // routing
     server.add_action( "/pubsub", boost::bind( on_pubsub_request, boost::ref( pubsub_connector ), _1, _2 ) );
     server.add_action( "/publish", boost::bind( &chat_adapter::create_response, boost::ref( adapter ), _1, _2 ) );
-    server.add_action( "/say", boost::bind( &chat_adapter::create_response, boost::ref( adapter ), _1, _2 ) );
 
     file::add_file_handler( server, "/jquery", boost::filesystem::canonical( __FILE__ ).parent_path() );
     file::add_file_handler( server, "/", boost::filesystem::canonical( __FILE__ ).parent_path() / "chat" );
 
     using namespace boost::asio::ip;
-    // JRL -- comment out for boost 1_55 support otherwise an exception is thrown "bind: Address already in use"
+    // JRL -- comment out for boost 1_54 support otherwise an exception is thrown "bind: Address already in use"
     // server.add_listener( tcp::endpoint( address( address_v4::any() ), 8080u ) );
     server.add_listener( tcp::endpoint( address( address_v6::any() ), 8080u ) );
 


### PR DESCRIPTION
Minor changes to a comment. The actual boost version used in local tests was 1_54. Also removed an unnecessary call to server.add_action() in chat.cpp that was left over from a previous experiment. 
